### PR TITLE
Desativar tipo de cozinha

### DIFF
--- a/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinha.java
+++ b/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinha.java
@@ -12,6 +12,8 @@ public class TipoDeCozinha {
     @Column(unique = true, nullable = false)
     private String nome;
 
+    private boolean ativo;
+
     @Deprecated
     protected TipoDeCozinha() {
     }
@@ -20,9 +22,12 @@ public class TipoDeCozinha {
         this.nome = nome;
     }
 
-    public TipoDeCozinha(Long id, String nome) {
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
         this.id = id;
-        this.nome = nome;
     }
 
     public String getNome() {
@@ -33,12 +38,12 @@ public class TipoDeCozinha {
         this.nome = nome;
     }
 
-    public Long getId() {
-        return id;
+    public boolean isAtivo() {
+        return ativo;
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public void toggleAtivo() {
+        this.ativo = !this.ativo;
     }
 
     @Override

--- a/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinhaController.java
+++ b/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinhaController.java
@@ -2,6 +2,7 @@ package br.com.cibus.tipodecozinha;
 
 import br.com.cibus.exceptions.NotFoundException;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
@@ -71,9 +72,12 @@ public class TipoDeCozinhaController {
         return "redirect:/admin/tipos-de-cozinha";
     }
 
-    @PostMapping("/admin/tipos-de-cozinha/remover/{id}")
-    public String remover(@PathVariable("id") Long id) {
-        tipoDeCozinhaRepository.deleteById(id);
+    @Transactional
+    @PostMapping("/admin/tipos-de-cozinha/toggleAtivo/{id}")
+    public String ativar(@PathVariable Long id) {
+        TipoDeCozinha tipoDeCozinha = tipoDeCozinhaRepository.findById(id).orElseThrow(NotFoundException::new);
+        tipoDeCozinha.toggleAtivo();
+
         return "redirect:/admin/tipos-de-cozinha";
     }
 }

--- a/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinhaRepository.java
+++ b/src/main/java/br/com/cibus/tipodecozinha/TipoDeCozinhaRepository.java
@@ -1,7 +1,6 @@
 package br.com.cibus.tipodecozinha;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 
 import java.util.List;
 

--- a/src/main/resources/db/migration/V2021.05.20.11.24.05__adiciona_coluna_status_em_tipo_de_cozinha.sql
+++ b/src/main/resources/db/migration/V2021.05.20.11.24.05__adiciona_coluna_status_em_tipo_de_cozinha.sql
@@ -1,0 +1,1 @@
+alter table tipo_de_cozinha add column ativo bool default true;

--- a/src/main/webapp/WEB-INF/views/tipo-de-cozinha/listagem.jsp
+++ b/src/main/webapp/WEB-INF/views/tipo-de-cozinha/listagem.jsp
@@ -29,6 +29,7 @@
                 <thead>
                 <tr>
                     <th>Nome</th>
+                    <th>Situação</th>
                     <th></th>
                 </tr>
                 </thead>
@@ -39,6 +40,7 @@
                     <c:set var="acaoAtual" value="${tipoDeCozinha.isAtivo() ? 'Desativar' : 'Ativar'}"/>
                     <tr class="${trClass}">
                         <td class="nome-tipo-de-cozinha">${tipoDeCozinha.nome}</td>
+                        <td class="situacao-tipo-de-cozinha">${tipoDeCozinha.isAtivo() ? 'Ativo' : 'Inativo'}</td>
                         <td class="d-flex justify-content-end">
                             <form class="form-remover-tipo-de-cozinha" method="post" action="/admin/tipos-de-cozinha/toggleAtivo/${tipoDeCozinha.id}">
                                 <button class="button-${acaoAtual.toLowerCase()}-tipo-de-cozinha btn ${btnClass} me-2" type="submit">${acaoAtual}</button>

--- a/src/main/webapp/WEB-INF/views/tipo-de-cozinha/listagem.jsp
+++ b/src/main/webapp/WEB-INF/views/tipo-de-cozinha/listagem.jsp
@@ -34,13 +34,16 @@
                 </thead>
                 <tbody class="align-middle">
                 <c:forEach items="${tiposDeCozinha}" var="tipoDeCozinha">
-                    <tr>
+                    <c:set var="trClass" value="${tipoDeCozinha.isAtivo() ? 'ativo' : 'inativo text-secondary'}"/>
+                    <c:set var="btnClass" value="${tipoDeCozinha.isAtivo() ? 'btn-danger' : 'btn-warning'}"/>
+                    <c:set var="acaoAtual" value="${tipoDeCozinha.isAtivo() ? 'Desativar' : 'Ativar'}"/>
+                    <tr class="${trClass}">
                         <td class="nome-tipo-de-cozinha">${tipoDeCozinha.nome}</td>
                         <td class="d-flex justify-content-end">
-                            <a href="/admin/tipos-de-cozinha/editar/${tipoDeCozinha.id}" class="link-editar-tipo-de-cozinha btn btn-primary me-2">Editar</a>
-                            <form class="form-remover-tipo-de-cozinha" method="post" action="/admin/tipos-de-cozinha/remover/${tipoDeCozinha.id}">
-                                <button class="button-remover-tipo-de-cozinha btn btn-danger" type="submit">Remover</button>
+                            <form class="form-remover-tipo-de-cozinha" method="post" action="/admin/tipos-de-cozinha/toggleAtivo/${tipoDeCozinha.id}">
+                                <button class="button-${acaoAtual.toLowerCase()}-tipo-de-cozinha btn ${btnClass} me-2" type="submit">${acaoAtual}</button>
                             </form>
+                            <a href="/admin/tipos-de-cozinha/editar/${tipoDeCozinha.id}" class="link-editar-tipo-de-cozinha btn btn-primary">Editar</a>
                         </td>
                     </tr>
                 </c:forEach>

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
@@ -138,7 +138,6 @@ class TipoDeCozinhaControllerTest {
     @Test
     void toggleAtivar() throws Exception {
         TipoDeCozinha egipcia = new TipoDeCozinha("Egípcia");
-        assertThat(egipcia.isAtivo()).isFalse();
 
         when(tipoDeCozinhaRepository.findById(1L)).thenReturn(Optional.of(egipcia));
 

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -135,11 +136,30 @@ class TipoDeCozinhaControllerTest {
     }
 
     @Test
-    void remover() throws Exception {
-        mockMvc.perform(post("/admin/tipos-de-cozinha/remover/1"))
+    void ativar() throws Exception {
+        TipoDeCozinha egipcia = new TipoDeCozinha("Egípcia");
+        egipcia.desativa();
+
+        when(tipoDeCozinhaRepository.findById(1L)).thenReturn(Optional.of(egipcia));
+
+        mockMvc.perform(post("/admin/tipos-de-cozinha/ativar/1"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", "/admin/tipos-de-cozinha"));
 
-        verify(tipoDeCozinhaRepository).deleteById(1L);
+        assertThat(egipcia.isAtivo()).isTrue();
+    }
+
+    @Test
+    void desativar() throws Exception {
+        TipoDeCozinha egipcia = new TipoDeCozinha("Egípcia");
+        egipcia.ativa();
+
+        when(tipoDeCozinhaRepository.findById(1L)).thenReturn(Optional.of(egipcia));
+
+        mockMvc.perform(post("/admin/tipos-de-cozinha/desativar/1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", "/admin/tipos-de-cozinha"));
+
+        assertThat(egipcia.isAtivo()).isFalse();
     }
 }

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaControllerTest.java
@@ -136,30 +136,16 @@ class TipoDeCozinhaControllerTest {
     }
 
     @Test
-    void ativar() throws Exception {
+    void toggleAtivar() throws Exception {
         TipoDeCozinha egipcia = new TipoDeCozinha("Egípcia");
-        egipcia.desativa();
+        assertThat(egipcia.isAtivo()).isFalse();
 
         when(tipoDeCozinhaRepository.findById(1L)).thenReturn(Optional.of(egipcia));
 
-        mockMvc.perform(post("/admin/tipos-de-cozinha/ativar/1"))
+        mockMvc.perform(post("/admin/tipos-de-cozinha/toggleAtivo/1"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", "/admin/tipos-de-cozinha"));
 
         assertThat(egipcia.isAtivo()).isTrue();
-    }
-
-    @Test
-    void desativar() throws Exception {
-        TipoDeCozinha egipcia = new TipoDeCozinha("Egípcia");
-        egipcia.ativa();
-
-        when(tipoDeCozinhaRepository.findById(1L)).thenReturn(Optional.of(egipcia));
-
-        mockMvc.perform(post("/admin/tipos-de-cozinha/desativar/1"))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(header().string("Location", "/admin/tipos-de-cozinha"));
-
-        assertThat(egipcia.isAtivo()).isFalse();
     }
 }

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaEndToEndTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaEndToEndTest.java
@@ -12,8 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.list;
 
@@ -125,16 +123,24 @@ public class TipoDeCozinhaEndToEndTest {
     }
 
     @Test
-    void remove() {
+    void toggleAtivo() {
         ListarTipoDeCozinhaPageObject listagem = abrirListagem();
 
-        String nomeRemovido = "Chinesa";
-        listagem.clickRemover(nomeRemovido);
+        String nomeDesativado = "Chinesa";
+        listagem.clickDesativar(nomeDesativado);
 
         assertThat(listagem.ehPaginaAtual()).isTrue();
-        assertThat(listagem.nomesDasLinhasDaTabela())
-                .doesNotContain(nomeRemovido)
-                .hasSize(3);
+        assertThat(listagem.nomesDasLinhasInativasDaTabela())
+                .contains(nomeDesativado)
+                .hasSize(1);
+
+        String nomeAtivado = "Chinesa";
+        listagem.clickAtivar(nomeAtivado);
+
+        assertThat(listagem.ehPaginaAtual()).isTrue();
+        assertThat(listagem.nomesDasLinhasAtivasDaTabela())
+                .contains(nomeAtivado)
+                .hasSize(4);
     }
 
     private String baseURL() {

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaRepositoryTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaRepositoryTest.java
@@ -2,8 +2,6 @@ package br.com.cibus.tipodecozinha;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaTest.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/TipoDeCozinhaTest.java
@@ -1,0 +1,21 @@
+package br.com.cibus.tipodecozinha;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TipoDeCozinhaTest {
+
+    @Test
+    void toggleAtivoDeveInverterEstadoInicial() {
+        TipoDeCozinha canadense = new TipoDeCozinha("Canadense");
+        assertThat(canadense.isAtivo()).isFalse();
+
+        canadense.toggleAtivo();
+        assertThat(canadense.isAtivo()).isTrue();
+
+        canadense.toggleAtivo();
+        assertThat(canadense.isAtivo()).isFalse();
+    }
+
+}

--- a/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
@@ -15,9 +15,12 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
     private By titulo = By.className("titulo");
     private By nomeDaTabela = By.className("nome-tipo-de-cozinha");
     private By linhasDaTabela = By.cssSelector("table.table tbody tr");
+    private By linhasAtivasDaTabela = By.cssSelector("table.table tbody tr.ativo");
+    private By linhasInativasDaTabela = By.cssSelector("table.table tbody tr.inativo");
     private By linkAdicionarNovo = By.className("link-adicionar-novo-tipo-de-cozinha");
     private By linkEditar = By.className("link-editar-tipo-de-cozinha");
-    private By botaoRemover = By.className("button-remover-tipo-de-cozinha");
+    private By botaoAtivar = By.className("button-ativar-tipo-de-cozinha");
+    private By botaoDesativar = By.className("button-desativar-tipo-de-cozinha");
 
     public ListarTipoDeCozinhaPageObject(WebDriver browser, String urlBase) {
         super(browser, urlBase);
@@ -45,21 +48,50 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
         return new EditarTipoDeCozinhaPageObject(browser, urlBase, id);
     }
 
-    public void clickRemover(String nomeTipoDeCozinha) {
+    public void clickAtivar(String nomeTipoDeCozinha) {
         WebElement linha = linhasDaTabela().stream()
                 .filter(el -> el.findElement(nomeDaTabela).getText().equals(nomeTipoDeCozinha))
                 .findFirst()
                 .orElseThrow(NotFoundException::new);
 
-        linha.findElement(botaoRemover).click();
+        linha.findElement(botaoAtivar).click();
     }
 
-    public List<WebElement> linhasDaTabela() {
+    public void clickDesativar(String nomeTipoDeCozinha) {
+        WebElement linha = linhasDaTabela().stream()
+                .filter(el -> el.findElement(nomeDaTabela).getText().equals(nomeTipoDeCozinha))
+                .findFirst()
+                .orElseThrow(NotFoundException::new);
+
+        linha.findElement(botaoDesativar).click();
+    }
+
+    private List<WebElement> linhasDaTabela() {
         return browser.findElements(linhasDaTabela);
     }
 
+    private List<WebElement> linhasAtivasDaTabela() {
+        return browser.findElements(linhasAtivasDaTabela);
+    }
+
+    private List<WebElement> linhasInativasDaTabela() {
+        return browser.findElements(linhasInativasDaTabela);
+    }
+
     public List<String> nomesDasLinhasDaTabela() {
-        return linhasDaTabela().stream()
+        return buscaNomesDasLinhasDaTabela(linhasDaTabela());
+    }
+
+    public List<String> nomesDasLinhasAtivasDaTabela() {
+        return buscaNomesDasLinhasDaTabela(linhasAtivasDaTabela());
+    }
+
+    public List<String> nomesDasLinhasInativasDaTabela() {
+        return buscaNomesDasLinhasDaTabela(linhasInativasDaTabela());
+    }
+
+    private List<String> buscaNomesDasLinhasDaTabela(List<WebElement> linhas) {
+        return linhas.stream()
                 .map(el -> el.findElement(nomeDaTabela).getText())
                 .collect(Collectors.toList());
     }

--- a/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
@@ -14,9 +14,8 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
 
     private By titulo = By.className("titulo");
     private By nomeDaTabela = By.className("nome-tipo-de-cozinha");
+    private By situacaoDaTabela = By.className("situacao-tipo-de-cozinha");
     private By linhasDaTabela = By.cssSelector("table.table tbody tr");
-    private By linhasAtivasDaTabela = By.cssSelector("table.table tbody tr.ativo");
-    private By linhasInativasDaTabela = By.cssSelector("table.table tbody tr.inativo");
     private By linkAdicionarNovo = By.className("link-adicionar-novo-tipo-de-cozinha");
     private By linkEditar = By.className("link-editar-tipo-de-cozinha");
     private By botaoAtivar = By.className("button-ativar-tipo-de-cozinha");
@@ -70,24 +69,22 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
         return browser.findElements(linhasDaTabela);
     }
 
-    private List<WebElement> linhasAtivasDaTabela() {
-        return browser.findElements(linhasAtivasDaTabela);
-    }
-
-    private List<WebElement> linhasInativasDaTabela() {
-        return browser.findElements(linhasInativasDaTabela);
-    }
-
     public List<String> nomesDasLinhasDaTabela() {
         return buscaNomesDasLinhasDaTabela(linhasDaTabela());
     }
 
     public List<String> nomesDasLinhasAtivasDaTabela() {
-        return buscaNomesDasLinhasDaTabela(linhasAtivasDaTabela());
+        return linhasDaTabela().stream()
+                .filter(linha -> linha.findElement(situacaoDaTabela).getText().equals("Ativo"))
+                .map(linha -> linha.findElement(nomeDaTabela).getText())
+                .collect(Collectors.toList());
     }
 
     public List<String> nomesDasLinhasInativasDaTabela() {
-        return buscaNomesDasLinhasDaTabela(linhasInativasDaTabela());
+        return linhasDaTabela().stream()
+                .filter(linha -> linha.findElement(situacaoDaTabela).getText().equals("Inativo"))
+                .map(linha -> linha.findElement(nomeDaTabela).getText())
+                .collect(Collectors.toList());
     }
 
     private List<String> buscaNomesDasLinhasDaTabela(List<WebElement> linhas) {

--- a/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
+++ b/src/test/java/br/com/cibus/tipodecozinha/pageobjects/ListarTipoDeCozinhaPageObject.java
@@ -70,7 +70,9 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
     }
 
     public List<String> nomesDasLinhasDaTabela() {
-        return buscaNomesDasLinhasDaTabela(linhasDaTabela());
+        return linhasDaTabela().stream()
+                .map(el -> el.findElement(nomeDaTabela).getText())
+                .collect(Collectors.toList());
     }
 
     public List<String> nomesDasLinhasAtivasDaTabela() {
@@ -84,12 +86,6 @@ public class ListarTipoDeCozinhaPageObject extends PageObject {
         return linhasDaTabela().stream()
                 .filter(linha -> linha.findElement(situacaoDaTabela).getText().equals("Inativo"))
                 .map(linha -> linha.findElement(nomeDaTabela).getText())
-                .collect(Collectors.toList());
-    }
-
-    private List<String> buscaNomesDasLinhasDaTabela(List<WebElement> linhas) {
-        return linhas.stream()
-                .map(el -> el.findElement(nomeDaTabela).getText())
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
>Ao deletar um tipo de cozinha, teria que deletar todos os restaurantes associados.
Uma solução mais interessantes seria apenas desativar um tipo de cozinha, ao invés de deletá-los. O layout seria parecido, com um botão desativar na listagem. Porém, deveríamos mostar o status (ativo/inativo) na listagem de tipo de cozinha.